### PR TITLE
优化通知提示和界面部分功能

### DIFF
--- a/src/MeoAsstGui/Helper/ScrollViewerBinding.cs
+++ b/src/MeoAsstGui/Helper/ScrollViewerBinding.cs
@@ -9,8 +9,10 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY
 
+using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Shapes;
 
 namespace MeoAsstGui
 {
@@ -30,54 +32,40 @@ namespace MeoAsstGui
         /// <summary>
         /// Just a flag that the binding has been applied.
         /// </summary>
-        private static readonly DependencyProperty VerticalScrollBindingProperty =
-            DependencyProperty.RegisterAttached("VerticalScrollBinding", typeof(bool?), typeof(ScrollViewerBinding));
+        private static readonly DependencyProperty VerticalOffsetBindingProperty =
+            DependencyProperty.RegisterAttached("VerticalOffsetBinding", typeof(bool?), typeof(ScrollViewerBinding));
 
         public static double GetVerticalOffset(DependencyObject depObj)
         {
-            ScrollViewer scrollViewer = depObj as ScrollViewer;
-            if (scrollViewer == null)
+            if (!(depObj is ScrollViewer))
                 return 0;
-            double maxHeight = scrollViewer.ScrollableHeight;
-            return (double)depObj.GetValue(VerticalOffsetProperty) / maxHeight;
+
+            return (double)depObj.GetValue(VerticalOffsetProperty);
         }
 
         public static void SetVerticalOffset(DependencyObject depObj, double value)
         {
-            if (value <= 1)
-            {
-                // by set
-                ScrollViewer scrollViewer = depObj as ScrollViewer;
-                if (scrollViewer == null)
-                    return;
-                double maxHeight = scrollViewer.ScrollableHeight;
+            if (!(depObj is ScrollViewer))
+                return;
 
-                depObj.SetValue(VerticalOffsetProperty, value * maxHeight);
-            }
-            else
-            {
-                // by scroll
-                depObj.SetValue(VerticalOffsetProperty, value);
-            }
+            depObj.SetValue(VerticalOffsetProperty, value);
         }
 
-        private static void OnVerticalOffsetPropertyChanged(DependencyObject d,
-            DependencyPropertyChangedEventArgs e)
+        private static void OnVerticalOffsetPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            ScrollViewer scrollViewer = d as ScrollViewer;
-            if (scrollViewer == null)
+            if (!(d is ScrollViewer scrollViewer))
                 return;
 
             BindVerticalOffset(scrollViewer);
             scrollViewer.ScrollToVerticalOffset((double)e.NewValue);
         }
 
-        public static void BindVerticalOffset(ScrollViewer scrollViewer)
+        private static void BindVerticalOffset(ScrollViewer scrollViewer)
         {
-            if (scrollViewer.GetValue(VerticalScrollBindingProperty) != null)
+            if (scrollViewer.GetValue(VerticalOffsetBindingProperty) != null)
                 return;
 
-            scrollViewer.SetValue(VerticalScrollBindingProperty, true);
+            scrollViewer.SetValue(VerticalOffsetBindingProperty, true);
             scrollViewer.ScrollChanged += (s, se) =>
             {
                 if (se.VerticalChange == 0)
@@ -88,32 +76,187 @@ namespace MeoAsstGui
 
         #endregion VerticalOffset attached property
 
-        #region ScrollableHeight attached property
+        #region ViewportHeight attached property
 
-        //public static readonly DependencyProperty ScrollableHeightProperty =
-        //    DependencyProperty.RegisterAttached("ScrollableHeight", typeof(double),
-        //    typeof(ScrollViewerBinding), new FrameworkPropertyMetadata(double.NaN, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnScrollableHeightPropertyChanged));
+        public static readonly DependencyProperty ViewportHeightProperty =
+            DependencyProperty.RegisterAttached("ViewportHeight", typeof(double),
+            typeof(ScrollViewerBinding), new FrameworkPropertyMetadata(double.NaN,
+                FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+                OnViewportHeightPropertyChanged));
 
-        //public static double GetScrollableHeight(DependencyObject depObj)
-        //{
-        //    ScrollViewer scrollViewer = depObj as ScrollViewer;
-        //    if (scrollViewer == null)
-        //        return 0;
-        //    return scrollViewer.ScrollableHeight;
-        //}
+        private static readonly DependencyProperty ViewportHeightBindingProperty =
+            DependencyProperty.RegisterAttached("ViewportHeightBinding", typeof(bool?), typeof(ScrollViewerBinding));
 
-        //public static void SetScrollableHeight(DependencyObject depObj, double value)
-        //{
-        //    // pass
-        //}
+        public static double GetViewportHeight(DependencyObject depObj)
+        {
+            if (!(depObj is ScrollViewer scrollViewer))
+                return double.NaN;
 
-        //private static readonly DependencyProperty ScrollableHeightBindingProperty =
-        //    DependencyProperty.RegisterAttached("ScrollableHeightBinding", typeof(bool?), typeof(ScrollViewerBinding));
+            return scrollViewer.ViewportHeight;
+        }
 
-        //private static void OnScrollableHeightPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        //{
-        //}
+        public static void SetViewportHeight(DependencyObject depObj, double value)
+        {
+            if (!(depObj is ScrollViewer))
+                return;
 
-        #endregion ScrollableHeight attached property
+            depObj.SetValue(ViewportHeightProperty, value);
+        }
+
+        private static void OnViewportHeightPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (!(d is ScrollViewer scrollViewer))
+                return;
+
+            BindViewportHeight(scrollViewer);
+        }
+
+        private static void BindViewportHeight(ScrollViewer scrollViewer)
+        {
+            if (scrollViewer.GetValue(ViewportHeightBindingProperty) != null)
+                return;
+
+            scrollViewer.SetValue(ViewportHeightBindingProperty, true);
+
+            scrollViewer.Loaded += (s, se) =>
+            {
+                SetViewportHeight(scrollViewer, scrollViewer.ViewportHeight);
+            };
+
+            scrollViewer.ScrollChanged += (s, se) =>
+            {
+                SetViewportHeight(scrollViewer, se.ViewportHeight);
+            };
+        }
+
+        #endregion ViewportHeight attached property
+
+        #region ExtentHeight attached property
+
+        public static readonly DependencyProperty ExtentHeightProperty =
+            DependencyProperty.RegisterAttached("ExtentHeight", typeof(double),
+            typeof(ScrollViewerBinding), new FrameworkPropertyMetadata(double.NaN,
+                FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+                OnExtentHeightPropertyChanged));
+
+        private static readonly DependencyProperty ExtentHeightBindingProperty =
+            DependencyProperty.RegisterAttached("ExtentHeightBinding", typeof(bool?), typeof(ScrollViewerBinding));
+
+        public static double GetExtentHeight(DependencyObject depObj)
+        {
+            if (!(depObj is ScrollViewer scrollViewer))
+                return double.NaN;
+
+            return scrollViewer.ExtentHeight;
+        }
+
+        public static void SetExtentHeight(DependencyObject depObj, double value)
+        {
+            if (!(depObj is ScrollViewer))
+                return;
+
+            depObj.SetValue(ExtentHeightProperty, value);
+        }
+
+        private static void OnExtentHeightPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (!(d is ScrollViewer scrollViewer))
+                return;
+
+            BindExtentHeight(scrollViewer);
+        }
+
+        private static void BindExtentHeight(ScrollViewer scrollViewer)
+        {
+            if (scrollViewer.GetValue(ExtentHeightBindingProperty) != null)
+                return;
+
+            scrollViewer.SetValue(ExtentHeightBindingProperty, true);
+
+            scrollViewer.Loaded += (s, se) =>
+            {
+                SetExtentHeight(scrollViewer, scrollViewer.ExtentHeight);
+            };
+        }
+
+        #endregion ExtentHeight attached property
+
+        #region RectangleVerticalOffsetList attached property
+
+        /// <summary>
+        /// RectangleIndex attached property
+        /// </summary>
+        public static readonly DependencyProperty RectangleVerticalOffsetListProperty =
+            DependencyProperty.RegisterAttached("RectangleVerticalOffsetList",
+                typeof(List<double>),
+                typeof(ScrollViewerBinding),
+                new FrameworkPropertyMetadata(new List<double>(),
+                    FrameworkPropertyMetadataOptions.AffectsRender |
+                    FrameworkPropertyMetadataOptions.BindsTwoWayByDefault,
+                    OnRectangleVerticalOffsetListPropertyChanged));
+
+        /// <summary>
+        /// Just a flag that the binding has been applied.
+        /// </summary>
+        private static readonly DependencyProperty RectangleVerticalOffsetListBindingProperty =
+            DependencyProperty.RegisterAttached("RectangleVerticalOffsetListBinding", typeof(bool?), typeof(ScrollViewerBinding));
+
+        public static List<double> GetRectangleVerticalOffsetList(DependencyObject depObj)
+        {
+            return (List<double>)depObj.GetValue(RectangleVerticalOffsetListProperty);
+        }
+
+        public static void SetRectangleVerticalOffsetList(DependencyObject depObj, List<double> value)
+        {
+            if (!(depObj is ScrollViewer))
+                return;
+
+            depObj.SetValue(RectangleVerticalOffsetListProperty, value);
+        }
+
+        private static void OnRectangleVerticalOffsetListPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (!(d is ScrollViewer scrollViewer))
+                return;
+
+            BindRectangleVerticalOffsetList(scrollViewer);
+        }
+
+        private static void BindRectangleVerticalOffsetList(ScrollViewer scrollViewer)
+        {
+
+            if (scrollViewer.GetValue(RectangleVerticalOffsetListBindingProperty) != null)
+                return;
+
+            scrollViewer.SetValue(RectangleVerticalOffsetListBindingProperty, true);
+
+            // 当滚动条载入时，遍历 StackPanel 中的所有 Rectangle 子元素对应位置
+            scrollViewer.Loaded += (s, se) =>
+            {
+                if (!scrollViewer.HasContent || !(scrollViewer.Content is StackPanel))
+                    return;
+
+                var rectangleOffsetList = new List<double>();
+                var stackPanel = (StackPanel)scrollViewer.Content;
+                var point = new Point(0, scrollViewer.VerticalOffset);
+
+                foreach (var child in stackPanel.Children)
+                {
+                    // 以 Rectangle 为定位元素
+                    if (!(child is Rectangle))
+                        continue;
+
+                    // 转换计算并保存 Rectangle 在滚动面板中的垂直位置
+                    var targetPosition = ((FrameworkElement)child).TransformToVisual(scrollViewer).Transform(point);
+                    rectangleOffsetList.Add(targetPosition.Y);
+                }
+
+                if (rectangleOffsetList.Count > 0)
+                    SetRectangleVerticalOffsetList(scrollViewer, rectangleOffsetList);
+            };
+        }
+
+        #endregion RectangleVerticalOffsetList attached property
+
     }
 }

--- a/src/MeoAsstGui/Helper/ToastNotification.cs
+++ b/src/MeoAsstGui/Helper/ToastNotification.cs
@@ -1,0 +1,373 @@
+// MeoAsstGui - A part of the MeoAssistantArknights project
+// Copyright (C) 2021 MistEO and Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Media;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Microsoft.Win32;
+using Notification.Wpf;
+using Notification.Wpf.Base;
+using Notification.Wpf.Constants;
+using Notification.Wpf.Controls;
+
+namespace MeoAsstGui
+{
+    public class ToastNotification : IDisposable
+    {
+        private NotificationManager _notificationManager = new NotificationManager();
+
+        /// <summary>
+        /// 通知标题
+        /// </summary>
+        private string _notificationTitle = string.Empty;
+
+        /// <summary>
+        /// 通知文本内容
+        /// </summary>
+        private StringBuilder _contentCollection = new StringBuilder();
+
+        /// <summary>
+        /// 应用图标资源
+        /// </summary>
+        private ImageSource GetAppIcon()
+        {
+            try
+            {
+                var icon = Icon.ExtractAssociatedIcon(System.Windows.Forms.Application.ExecutablePath);
+                var imageSource = Imaging.CreateBitmapSourceFromHIcon(
+                    icon.Handle,
+                    Int32Rect.Empty,
+                    BitmapSizeOptions.FromEmptyOptions());
+
+                return imageSource;
+            }
+            catch (Exception)
+            {
+                return new BitmapImage();
+            }
+        }
+
+        /// <summary>
+        /// Toast通知，基于 Notification.Wpf 实现，方便管理通知样式
+        /// <para>建议使用 using 调用，如果不使用 using 调用，建议手动调用 Dispose() 方法释放</para>
+        /// </summary>
+        /// <param name="title">通知标题</param>
+        public ToastNotification(string title = null)
+        {
+            // 初始化通知标题
+            _notificationTitle = title ?? _notificationTitle;
+
+            #region 初始化 Notification.Wpf 默认静态配置
+
+            // 同时显示最大数量
+            NotificationConstants.NotificationsOverlayWindowMaxCount = 5;
+
+            // 默认显示位置
+            NotificationConstants.MessagePosition = NotificationPosition.BottomRight;
+
+            // 最小显示宽度
+            NotificationConstants.MinWidth = 350d;
+
+            // 最大显示宽度
+            NotificationConstants.MaxWidth = 380d;
+
+            #endregion
+        }
+
+        /// <summary>
+        /// 添加一行内容文本
+        /// </summary>
+        /// <param name="text">文本内容</param>
+        /// <returns>返回类本身，可继续调用其它方法</returns>
+        public ToastNotification AddContentText(string text = null)
+        {
+            _contentCollection.AppendLine(text ?? string.Empty);
+            return this;
+        }
+
+        #region 通知提示音
+
+        #region 通知提示音列表枚举
+
+        public enum NotificationSounds
+        {
+            [Description("默认响声")]
+            Beep,
+
+            [Description("感叹号")]
+            Exclamation,
+
+            [Description("星号")]
+            Asterisk,
+
+            [Description("问题")]
+            Question,
+
+            [Description("关键性停止")]
+            Hand,
+
+            [Description("通知 (Windows 10 及以上特有，低版本系统直接用也可以)")]
+            Notification,
+
+            [Description("无声")]
+            None
+        }
+
+        #endregion
+
+        /// <summary>
+        /// 播放通知提示音
+        /// 如果要播放音频文件，参考微软文档 SoundPlayer 类
+        /// </summary>
+        /// <param name="sounds">提示音类型</param>
+        protected async Task PlayNotificationSoundAsync(NotificationSounds sounds = NotificationSounds.None)
+        {
+            await Task.Run(() =>
+            {
+
+                try
+                {
+                    switch (sounds)
+                    {
+                        case NotificationSounds.Exclamation: SystemSounds.Exclamation.Play(); break;
+                        case NotificationSounds.Asterisk: SystemSounds.Asterisk.Play(); break;
+                        case NotificationSounds.Question: SystemSounds.Question.Play(); break;
+                        case NotificationSounds.Beep: SystemSounds.Beep.Play(); break;
+                        case NotificationSounds.Hand: SystemSounds.Hand.Play(); break;
+
+                        case NotificationSounds.Notification:
+                            using (var key = Registry.CurrentUser.OpenSubKey(@"AppEvents\Schemes\Apps\.Default\Notification.Default\.Current"))
+                            {
+                                if (key != null)
+                                {
+                                    // 获取 (Default) 项
+                                    var o = key.GetValue(null);
+                                    if (o != null)
+                                    {
+                                        var theSound = new SoundPlayer((string)o);
+                                        theSound.Play();
+                                    }
+                                }
+                                else
+                                {
+                                    // 如果不支持就播放其它提示音
+                                    PlayNotificationSoundAsync(NotificationSounds.Asterisk);
+                                }
+                            }
+                            break;
+
+                        case NotificationSounds.None:
+                        default: break;
+                    }
+                }
+                catch (Exception) { }
+            }).ConfigureAwait(false);
+        }
+
+        #endregion
+
+        #region 通知按钮设置
+
+        #region 通知按钮变量
+        // 左边按钮
+        protected string _buttonLeftText = null;
+        protected Action _buttonLeftAction = null;
+
+        // 右边按钮
+        protected string _buttonRightText = null;
+        protected Action _buttonRightAction = null;
+        #endregion
+
+        /// <summary>
+        /// 给通知添加一个在左边的按钮，比如确定按钮，多次设置只会按最后一次设置生效
+        /// </summary>
+        /// <param name="text">按钮标题</param>
+        /// <param name="action">按钮执行方法</param>
+        /// <returns>返回类本身，可继续调用其它方法</returns>
+        public ToastNotification AddButtonLeft(string text, Action action)
+        {
+            _buttonLeftText = text;
+            _buttonLeftAction = action;
+            return this;
+        }
+
+        /// <summary>
+        /// 给通知添加一个在右边的按钮，比如取消按钮，多次设置只会按最后一次设置生效
+        /// </summary>
+        /// <param name="text">按钮标题</param>
+        /// <param name="action">按钮执行方法</param>
+        /// <returns>返回类本身，可继续调用其它方法</returns>
+        public ToastNotification AddButtonRight(string text, Action action)
+        {
+            _buttonRightText = text;
+            _buttonRightAction = action;
+            return this;
+        }
+
+        #endregion
+
+        #region 通知显示
+
+        #region 通知基本字体样式和内容模板
+
+        /// <summary>
+        /// 创建一个基本文本字体样式
+        /// </summary>
+        public TextContentSettings BaseTextSettings => new TextContentSettings()
+        {
+            FontStyle = FontStyles.Normal,
+            FontFamily = new System.Windows.Media.FontFamily("Microsoft Yahei"),
+            FontSize = 14,
+            FontWeight = FontWeights.Normal,
+            TextAlignment = TextAlignment.Left,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            VerticalTextAlignment = VerticalAlignment.Stretch,
+            Opacity = 1d
+        };
+
+        /// <summary>
+        /// 创建一个基本通知内容模板
+        /// </summary>
+        public NotificationContent BaseContent()
+        {
+            var content = new NotificationContent()
+            {
+                Title = _notificationTitle,
+                Message = _contentCollection.ToString(),
+
+                Type = NotificationType.None,
+                Icon = GetAppIcon(),
+                CloseOnClick = true,
+
+                RowsCount = 1,
+                TrimType = NotificationTextTrimType.AttachIfMoreRows,
+
+                Background = (SolidColorBrush)new BrushConverter().ConvertFrom("#FF332A3A"),
+
+                LeftButtonContent = _buttonLeftText ?? NotificationConstants.DefaultLeftButtonContent,
+                LeftButtonAction = _buttonLeftAction ?? null,
+
+                RightButtonContent = _buttonRightText ?? NotificationConstants.DefaultRightButtonContent,
+                RightButtonAction = _buttonRightAction ?? null,
+            };
+
+            // 默认的标题文本样式
+            var titleTextSettings = BaseTextSettings;
+            titleTextSettings.FontSize = 18d;
+            content.TitleTextSettings = titleTextSettings;
+
+            // 默认的内容文本样式
+            var messageTextSettings = BaseTextSettings;
+            content.MessageTextSettings = messageTextSettings;
+
+            return content;
+        }
+
+        #endregion
+
+        #region 显示通知方法
+
+        /// <summary>
+        /// 显示通知
+        /// </summary>
+        /// <param name="lifeTime">通知显示时间 (s)</param>
+        /// <param name="row">内容显示行数，如果内容太多建议使用 ShowMore()</param>
+        /// <param name="sound">播放提示音</param>
+        /// <param name="notificationContent">通知内容</param>
+        public void Show(double lifeTime = 10d, uint row = 1,
+            NotificationSounds sound = NotificationSounds.Notification,
+            NotificationContent notificationContent = null)
+        {
+            notificationContent = notificationContent ?? BaseContent();
+
+            notificationContent.RowsCount = row;
+
+            // 调整显示时间，如果存在按钮的情况下显示时间将强制设为最大时间
+            lifeTime = lifeTime < 3d ? 3d : lifeTime;
+
+            var timeSpan = _buttonLeftAction == null && _buttonRightAction == null
+                ? TimeSpan.FromSeconds(lifeTime)
+                : TimeSpan.MaxValue;
+
+            // 显示通知
+            _notificationManager.Show(
+                notificationContent,
+                expirationTime: timeSpan,
+                ShowXbtn: false);
+
+            // 播放通知提示音
+            PlayNotificationSoundAsync(sound);
+        }
+
+        /// <summary>
+        /// 显示内容更多的通知
+        /// </summary>
+        /// <param name="lifeTime">通知显示时间 (s)</param>
+        /// <param name="row">内容显示行数，只用于预览一部分通知，多出内容会放在附加按钮的窗口中</param>
+        /// <param name="sound">播放提示音，不设置就没有声音</param>
+        /// <param name="notificationContent">通知内容</param>
+        public void ShowMore(double lifeTime = 12d, uint row = 2,
+            NotificationSounds sound = NotificationSounds.None,
+            NotificationContent notificationContent = null)
+        {
+            notificationContent = notificationContent ?? BaseContent();
+            notificationContent.TrimType = NotificationTextTrimType.Attach;
+
+            Show(lifeTime: lifeTime,
+                 row: row,
+                 sound: sound,
+                 notificationContent: notificationContent);
+        }
+
+        /// <summary>
+        /// 显示公招特殊标签通知
+        /// </summary>
+        /// <param name="row">内容显示行数，比如第 2 行用来放星星</param>
+        public void ShowRecruit(uint row = 1)
+        {
+            var content = BaseContent();
+
+            // 给通知染上资深标签相似的颜色
+            content.Background = (SolidColorBrush)new BrushConverter().ConvertFrom("#FF401804");
+            content.Foreground = (SolidColorBrush)new BrushConverter().ConvertFrom("#FFFFC800");
+
+            Show(row: row,
+                 sound: NotificationSounds.Notification,
+                 notificationContent: content);
+        }
+
+        #endregion
+
+        #endregion
+
+        /// <summary>
+        /// 通知使用完后释放已使用的数据
+        /// </summary>
+        public void Dispose()
+        {
+            _contentCollection.Clear();
+
+            _notificationManager = null;
+            _notificationTitle = null;
+            _contentCollection = null;
+            _buttonLeftText = _buttonRightText = null;
+            _buttonLeftAction = _buttonRightAction = null;
+        }
+
+    }
+}

--- a/src/MeoAsstGui/Helper/ViewStatusStorage.cs
+++ b/src/MeoAsstGui/Helper/ViewStatusStorage.cs
@@ -47,12 +47,9 @@ namespace MeoAsstGui
                 using (StreamReader sr = new StreamReader(_configFilename))
                 {
                     string jsonStr = sr.ReadToEnd();
-                    _viewStatus = (JObject)JsonConvert.DeserializeObject(jsonStr);
-                    // 文件存在但为空，会读出来一个null，感觉c#这库有bug
-                    if (_viewStatus == null)
-                    {
-                        _viewStatus = new JObject();
-                    }
+
+                    // 文件存在但为空，会读出来一个null，感觉c#这库有bug，如果是null 就赋值一个空JObject
+                    _viewStatus = (JObject)JsonConvert.DeserializeObject(jsonStr) ?? new JObject();
                 }
             }
             catch (Exception)

--- a/src/MeoAsstGui/MeoAsstGui.csproj
+++ b/src/MeoAsstGui/MeoAsstGui.csproj
@@ -280,7 +280,7 @@
       <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="Notification.Wpf">
-      <Version>6.1.0</Version>
+      <Version>6.1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Stylet">
       <Version>1.3.6</Version>

--- a/src/MeoAsstGui/MeoAsstGui.csproj
+++ b/src/MeoAsstGui/MeoAsstGui.csproj
@@ -91,6 +91,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
@@ -114,6 +115,7 @@
     <Compile Include="Helper\AutoScroll.cs" />
     <Compile Include="Helper\CombData.cs" />
     <Compile Include="Helper\LogItemViewModel.cs" />
+    <Compile Include="Helper\ToastNotification.cs" />
     <Compile Include="Helper\ScrollViewerBinding.cs" />
     <Compile Include="Helper\ViewStatusStorage.cs" />
     <Compile Include="Helper\FlowDocumentPagePadding.cs" />
@@ -222,6 +224,7 @@
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <None Include=".editorconfig" />
     <None Include="Properties\Settings.settings">
@@ -267,9 +270,6 @@
     <PackageReference Include="Microsoft.NETCore.Platforms">
       <Version>5.0.4</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
-      <Version>7.1.1</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.Win32.Primitives">
       <Version>4.3.0</Version>
     </PackageReference>
@@ -278,6 +278,9 @@
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>13.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="Notification.Wpf">
+      <Version>6.1.0</Version>
     </PackageReference>
     <PackageReference Include="Stylet">
       <Version>1.3.6</Version>

--- a/src/MeoAsstGui/ViewModels/TaskQueueViewModel.cs
+++ b/src/MeoAsstGui/ViewModels/TaskQueueViewModel.cs
@@ -59,14 +59,16 @@ namespace MeoAsstGui
             }
             TaskItemViewModels = new ObservableCollection<DragItemViewModel>(temp_order_list);
 
-            StageList = new List<CombData>();
-            StageList.Add(new CombData { Display = "当前关卡", Value = "" });
-            StageList.Add(new CombData { Display = "上次作战", Value = "LastBattle" });
-            StageList.Add(new CombData { Display = "剿灭作战", Value = "Annihilation" });
-            StageList.Add(new CombData { Display = "龙门币-5", Value = "CE-5" });
-            StageList.Add(new CombData { Display = "红票-5", Value = "AP-5" });
-            StageList.Add(new CombData { Display = "经验-5", Value = "LS-5" });
-            StageList.Add(new CombData { Display = "技能-5", Value = "CA-5" });
+            StageList = new List<CombData>
+            {
+                new CombData { Display = "当前关卡", Value = string.Empty },
+                new CombData { Display = "上次作战", Value = "LastBattle" },
+                new CombData { Display = "剿灭作战", Value = "Annihilation" },
+                new CombData { Display = "龙门币-5", Value = "CE-5" },
+                new CombData { Display = "红票-5", Value = "AP-5" },
+                new CombData { Display = "经验-5", Value = "LS-5" },
+                new CombData { Display = "技能-5", Value = "CA-5" }
+            };
             // “风雪过境” 活动关卡
             //StageList.Add(new CombData { Display = "BI-7", Value = "BI-7" });
             //StageList.Add(new CombData { Display = "BI-8", Value = "BI-8" });
@@ -86,6 +88,8 @@ namespace MeoAsstGui
         public async void LinkStart()
         {
             ClearLog();
+
+            SaveSettingValue();
 
             AddLog("正在连接模拟器……");
 
@@ -175,6 +179,19 @@ namespace MeoAsstGui
             asstProxy.AsstStop();
             AddLog("已停止");
             Idle = true;
+        }
+
+        /// <summary>
+        /// 保存界面设置数值
+        /// </summary>
+        private void SaveSettingValue()
+        {
+            // 吃理智药个数
+            ViewStatusStorage.Set("MainFunction.UseMedicine.Quantity", MedicineNumber);
+            // 吃石头颗数
+            ViewStatusStorage.Set("MainFunction.UseStone.Quantity", StoneNumber);
+            // 指定刷关次数
+            ViewStatusStorage.Set("MainFunction.TimesLimited.Quantity", MaxTimes);
         }
 
         private bool appendFight()
@@ -272,11 +289,11 @@ namespace MeoAsstGui
 
         public void CheckAndShutdown()
         {
-            if (Shutdown == true)
+            if (Shutdown)
             {
                 System.Diagnostics.Process.Start("shutdown.exe", "-s -t 60");
 
-                var result = _windowManager.ShowMessageBox("已刷完，即将关机，是否取消？", "提示", MessageBoxButton.OK);
+                var result = _windowManager.ShowMessageBox("已刷完，即将关机，是否取消？", "提示", MessageBoxButton.OK, MessageBoxImage.Question);
                 if (result == MessageBoxResult.OK)
                 {
                     System.Diagnostics.Process.Start("shutdown.exe", "-a");
@@ -334,7 +351,7 @@ namespace MeoAsstGui
             }
         }
 
-        private string _medicineNumber = "999";
+        private string _medicineNumber = ViewStatusStorage.Get("MainFunction.UseMedicine.Quantity", "999");
 
         public string MedicineNumber
         {
@@ -360,7 +377,7 @@ namespace MeoAsstGui
             }
         }
 
-        private string _stoneNumber = "0";
+        private string _stoneNumber = ViewStatusStorage.Get("MainFunction.UseStone.Quantity", "0");
 
         public string StoneNumber
         {
@@ -382,7 +399,7 @@ namespace MeoAsstGui
             }
         }
 
-        private string _maxTimes = "5";
+        private string _maxTimes = ViewStatusStorage.Get("MainFunction.TimesLimited.Quantity", "5");
 
         public string MaxTimes
         {

--- a/src/MeoAsstGui/Views/SettingsView.xaml
+++ b/src/MeoAsstGui/Views/SettingsView.xaml
@@ -16,9 +16,11 @@
         <ListBox x:Name="MasterListBox" ItemsSource="{Binding ListTitle}" Grid.Column="0"  Margin="10"
                IsSynchronizedWithCurrentItem="true" SelectedIndex="{Binding SelectedIndex}" />
 
-        <ScrollViewer local:ScrollViewerBinding.VerticalOffset="{Binding ScrollOffset}"
-                      HorizontalAlignment="Stretch" Grid.Column="1" Margin="20, 10">
-            <!--local:ScrollViewerBinding.ScrollableHeight="{Binding ScrollHeight, Mode=OneWayToSource}"-->
+        <ScrollViewer HorizontalAlignment="Stretch" Grid.Column="1" Margin="20, 10"
+                      local:ScrollViewerBinding.ViewportHeight="{Binding ScrollViewportHeight}"
+                      local:ScrollViewerBinding.ExtentHeight="{Binding ScrollExtentHeight}"
+                      local:ScrollViewerBinding.VerticalOffset="{Binding ScrollOffset}"
+                      local:ScrollViewerBinding.RectangleVerticalOffsetList="{Binding RectangleVerticalOffsetList}">
             <StackPanel IsEnabled="{Binding Idle}">
                 <Rectangle HorizontalAlignment="Stretch" Fill="LightGray" Height="1" />
                 <TextBlock Style="{StaticResource TextBlockDefault}" Text="{Binding ListTitle[0]}" Foreground="Gray" Margin="5" VerticalAlignment="Center" HorizontalAlignment="Left" />


### PR DESCRIPTION
## 更新内容

* 更换微软的 Notification 为兼容多版本 Windows 的 Notification.WPF 通知
* 修复 AsstProxy 中初始化异常时 ShowMessageBox 会导致程序未响应的问题
* 给当前使用的 ShowMessageBox 消息框加上消息图标
* 增加了主界面上各个设置数值的保存
* 更换了设置页面滚动和菜单列表定位方法
* 优化一点 C# 代码格式冗余

## 其他说明

在之前公招出了高资、因为 MAA 使用 win10 通知、win7 系统不兼容就直接崩了、接着一不小心没把标签选上……
于是就决定插手改改通知了_(:з」∠)_ 

摸了将近一周才改了这点、不过最近貌似准备换成 WEB 界面、感觉这些更改可有可无了_(xз」∠)_ 

换了个通用的 wpf 通知、除了不像 win10 可以把通知存在通知中心、其它功能效果基本差不多
可以参考开源项目 Notification.WPF https://github.com/Platonenkov/Notification.Wpf