### PR TITLE
fix.修复界面toast通知线程调用时崩溃问题和一些其他改进

### DIFF
--- a/src/MeoAsstGui/Helper/AsstProxy.cs
+++ b/src/MeoAsstGui/Helper/AsstProxy.cs
@@ -351,7 +351,7 @@ namespace MeoAsstGui
                         string special = subTaskDetails["tag"].ToString();
                         using (var toast = new ToastNotification("公招提示"))
                         {
-                            toast.AddContentText(special).ShowRecruit();
+                            toast.AppendContentText(special).ShowRecruit();
                         }
                     }
                     break;
@@ -363,7 +363,7 @@ namespace MeoAsstGui
                         {
                             using (var toast = new ToastNotification($"公招出 {level} 星了哦！"))
                             {
-                                toast.AddContentText(new string('★', level)).ShowRecruit(row: 2);
+                                toast.AppendContentText(new string('★', level)).ShowRecruit(row: 2);
                             }
                             mainModel.AddLog(level + " 星 Tags", "darkorange", "Bold");
                         }
@@ -423,7 +423,7 @@ namespace MeoAsstGui
                         string special = subTaskDetails["tag"].ToString();
                         using (var toast = new ToastNotification("公招提示"))
                         {
-                            toast.AddContentText(special).ShowRecruit();
+                            toast.AppendContentText(special).ShowRecruit();
                         }
                     }
                     break;
@@ -453,7 +453,7 @@ namespace MeoAsstGui
                         {
                             using (var toast = new ToastNotification($"公招出 {level} 星了哦！"))
                             {
-                                toast.AddContentText(new string('★', level)).ShowRecruit(row: 2);
+                                toast.AppendContentText(new string('★', level)).ShowRecruit(row: 2);
                             }
                         }
                     }

--- a/src/MeoAsstGui/Helper/ScrollViewerBinding.cs
+++ b/src/MeoAsstGui/Helper/ScrollViewerBinding.cs
@@ -238,7 +238,7 @@ namespace MeoAsstGui
 
                 var rectangleOffsetList = new List<double>();
                 var stackPanel = (StackPanel)scrollViewer.Content;
-                var point = new Point(0, scrollViewer.VerticalOffset);
+                var point = new Point(10, scrollViewer.VerticalOffset);
 
                 foreach (var child in stackPanel.Children)
                 {

--- a/src/MeoAsstGui/Helper/ToastNotification.cs
+++ b/src/MeoAsstGui/Helper/ToastNotification.cs
@@ -65,6 +65,7 @@ namespace MeoAsstGui
         /// <summary>
         /// Toast通知，基于 Notification.Wpf 实现，方便管理通知样式
         /// <para>建议使用 using 调用，如果不使用 using 调用，建议手动调用 Dispose() 方法释放</para>
+        /// <para>在线程中必须使用 Dispatcher.Invoke 相关方法调用</para>
         /// </summary>
         /// <param name="title">通知标题</param>
         public ToastNotification(string title = null)
@@ -81,20 +82,20 @@ namespace MeoAsstGui
             NotificationConstants.MessagePosition = NotificationPosition.BottomRight;
 
             // 最小显示宽度
-            NotificationConstants.MinWidth = 350d;
+            NotificationConstants.MinWidth = 400d;
 
             // 最大显示宽度
-            NotificationConstants.MaxWidth = 380d;
+            NotificationConstants.MaxWidth = 460d;
 
             #endregion
         }
 
         /// <summary>
-        /// 添加一行内容文本
+        /// 添加一行文本内容
         /// </summary>
         /// <param name="text">文本内容</param>
-        /// <returns>返回类本身，可继续调用其它方法</returns>
-        public ToastNotification AddContentText(string text = null)
+        /// <returns>返回本类，可继续调用其它方法</returns>
+        public ToastNotification AppendContentText(string text = null)
         {
             _contentCollection.AppendLine(text ?? string.Empty);
             return this;
@@ -257,7 +258,7 @@ namespace MeoAsstGui
                 RowsCount = 1,
                 TrimType = NotificationTextTrimType.AttachIfMoreRows,
 
-                Background = (SolidColorBrush)new BrushConverter().ConvertFrom("#FF332A3A"),
+                Background = (SolidColorBrush)new BrushConverter().ConvertFrom("#FF1F3550"),
 
                 LeftButtonContent = _buttonLeftText ?? NotificationConstants.DefaultLeftButtonContent,
                 LeftButtonAction = _buttonLeftAction ?? null,
@@ -347,6 +348,21 @@ namespace MeoAsstGui
             content.Foreground = (SolidColorBrush)new BrushConverter().ConvertFrom("#FFFFC800");
 
             Show(row: row,
+                 sound: NotificationSounds.Notification,
+                 notificationContent: content);
+        }
+
+        /// <summary>
+        /// 显示更新版本的通知
+        /// </summary>
+        /// <param name="row">内容行数</param>
+        public void ShowUpdateVersion(uint row = 3)
+        {
+            var content = BaseContent();
+
+            content.Background = (SolidColorBrush)new BrushConverter().ConvertFrom("#FF007280");
+
+            ShowMore(row: row,
                  sound: NotificationSounds.Notification,
                  notificationContent: content);
         }

--- a/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
+++ b/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
@@ -93,14 +93,16 @@ namespace MeoAsstGui
             FacilityKey.Add("办公室", "Office");
             FacilityKey.Add("控制中枢", "Control");
 
-            UsesOfDronesList = new List<CombData>();
-            UsesOfDronesList.Add(new CombData { Display = "不使用无人机", Value = "_NotUse" });
-            UsesOfDronesList.Add(new CombData { Display = "贸易站-龙门币", Value = "Money" });
-            UsesOfDronesList.Add(new CombData { Display = "贸易站-合成玉", Value = "SyntheticJade" });
-            UsesOfDronesList.Add(new CombData { Display = "制造站-经验书", Value = "CombatRecord" });
-            UsesOfDronesList.Add(new CombData { Display = "制造站-赤金", Value = "PureGold" });
-            UsesOfDronesList.Add(new CombData { Display = "制造站-源石碎片", Value = "OriginStone" });
-            UsesOfDronesList.Add(new CombData { Display = "制造站-芯片组", Value = "Chip" });
+            UsesOfDronesList = new List<CombData>
+            {
+                new CombData { Display = "不使用无人机", Value = "_NotUse" },
+                new CombData { Display = "贸易站-龙门币", Value = "Money" },
+                new CombData { Display = "贸易站-合成玉", Value = "SyntheticJade" },
+                new CombData { Display = "制造站-经验书", Value = "CombatRecord" },
+                new CombData { Display = "制造站-赤金", Value = "PureGold" },
+                new CombData { Display = "制造站-源石碎片", Value = "OriginStone" },
+                new CombData { Display = "制造站-芯片组", Value = "Chip" }
+            };
 
             _dormThresholdLabel = "宿舍入驻心情阈值：" + _dormThreshold + "%";
         }
@@ -203,17 +205,24 @@ namespace MeoAsstGui
 
         private NotifyType _notifySource = NotifyType.None;
 
+        private System.Timers.Timer _resetNotifyTimer;
         private void ResetNotifySource()
         {
-            var t = new System.Timers.Timer(20);
-            t.Elapsed += new System.Timers.ElapsedEventHandler(delegate (object source, System.Timers.ElapsedEventArgs e)
+            if (_resetNotifyTimer != null)
+            {
+                _resetNotifyTimer.Stop();
+                _resetNotifyTimer.Close();
+            }
+            _resetNotifyTimer = new System.Timers.Timer(20);
+            _resetNotifyTimer.Elapsed += new System.Timers.ElapsedEventHandler(delegate (object source, System.Timers.ElapsedEventArgs e)
             {
                 _notifySource = NotifyType.None;
             });
-            t.AutoReset = false;
-            t.Enabled = true;
-            t.Start();
+            _resetNotifyTimer.AutoReset = false;
+            _resetNotifyTimer.Enabled = true;
+            _resetNotifyTimer.Start();
         }
+
         public double ScrollViewportHeight { get; set; }
 
         public double ScrollExtentHeight { get; set; }
@@ -267,7 +276,7 @@ namespace MeoAsstGui
                         if (isInRange)
                         {
                             // 滚动条滚动到底部，返回最后一个 Rectangle 索引
-                            if (ScrollOffset + ScrollViewportHeight >= ScrollExtentHeight)
+                            if (value + ScrollViewportHeight >= ScrollExtentHeight)
                             {
                                 SelectedIndex = RectangleVerticalOffsetList.Count - 1;
                                 ResetNotifySource();
@@ -276,7 +285,7 @@ namespace MeoAsstGui
 
                             // 根据出当前 ScrollOffset 选出最后一个在可视范围的 Rectangle 索引
                             var rectangleSelect = RectangleVerticalOffsetList.Select((n, i) => (
-                            rectangleAppeared: value + 10 >= n,
+                            rectangleAppeared: value >= n,
                             index: i
                             ));
 
@@ -312,7 +321,7 @@ namespace MeoAsstGui
 
         /* 企鹅数据设置 */
 
-        private string _penguinId = ViewStatusStorage.Get("Penguin.Id", "");
+        private string _penguinId = ViewStatusStorage.Get("Penguin.Id", string.Empty);
 
         public string PenguinId
         {


### PR DESCRIPTION
## 更新内容

* 修复 toast通知提示在非UI线程调用引起程式懵了的问题
* 修复 OTA 更新 stages.json 地址错误的问题
* 新增 3个OTA更新下载地址CDN接口，获取失败会尝试从下一个接口获取
* 新增 更新提示的 toast 通知样式
* 更改 部分 toast 通知样式
* 更改 设置页面滚动条滚动定位计算
* 调整 GUI 一些代码排版格式


## 其他说明

记得调用界面相关的操作时、要放到 UI 线程里处理（嗯嗯嗯记住了 （下次还是忘记）

toast通知调用应该不会再崩溃了（或许大概肯定吧

看了OTA更新部分、用 Dictionary 类型遍历一样的内容有点大材小用、而且发现有一个文件路径没改导致不能获取到更新、于是换了个符合需求的 List 类型、避免出现同样的问题

顺便增加 3个 OTA更新文件用的接口、基本上能保证更新稳定性、但我这用的时代眼泪Win7系统、连获取更新信息都不行、所以没有实际测试过、理论上应该没问题、测试只好留给大佬了……

今天又开始上班、有其他界面问题、有空再看（摆烂……\_(:з」∠)_ 