### PR TITLE
[experimental] feat. 增加WSA支持

### DIFF
--- a/resource/config.json
+++ b/resource/config.json
@@ -40,6 +40,7 @@
                 "swipe": "[Adb] -s [Address] shell input swipe [x1] [y1] [x2] [y2] [duration]",
                 "display": "[Adb] -s [Address] shell dumpsys window displays | grep init= | awk ' { print $3 } '",
                 "displayFormat": "cur=%dx%d",
+                "displayId": "",
                 "screencapRawWithGzip": "[Adb] -s [Address] exec-out \"screencap | gzip -1\"",
                 "screencapEncode": "[Adb] -s [Address] exec-out screencap -p",
                 "release": "[Adb] kill-server"
@@ -62,6 +63,7 @@
                 "swipe": "[Adb] -s [Address] shell input swipe [x1] [y1] [x2] [y2] [duration]",
                 "display": "[Adb] -s [Address] shell dumpsys window displays | grep init= | awk ' { print $3 } '",
                 "displayFormat": "cur=%dx%d",
+                "displayId": "",
                 "screencapRawWithGzip": "[Adb] -s [Address] exec-out \"screencap | gzip -1\"",
                 "screencapEncode": "[Adb] -s [Address] exec-out screencap -p",
                 "release": "[Adb] kill-server"
@@ -84,6 +86,7 @@
                 "swipe": "[Adb] -s [Address] shell input swipe [x1] [y1] [x2] [y2] [duration]",
                 "display": "[Adb] -s [Address] shell dumpsys window displays | grep init= | awk ' { print $3 } '",
                 "displayFormat": "cur=%dx%d",
+                "displayId": "",
                 "screencapRawWithGzip": "[Adb] -s [Address] exec-out \"screencap | gzip -1\"",
                 "screencapEncode": "[Adb] -s [Address] exec-out screencap -p",
                 "release": "[Adb] kill-server"
@@ -107,6 +110,7 @@
                 "swipe": "[Adb] -s [Address] shell input swipe [x1] [y1] [x2] [y2] [duration]",
                 "display": "[Adb] -s [Address] shell dumpsys window displays | grep init= | awk ' { print $3 } '",
                 "displayFormat": "cur=%dx%d",
+                "displayId": "",
                 "screencapRawWithGzip": "[Adb] -s [Address] shell \"screencap | gzip -1\"",
                 "screencapEncode": "[Adb] -s [Address] shell screencap -p",
                 "release": "[Adb] kill-server"
@@ -130,6 +134,7 @@
                 "swipe": "[Adb] -s [Address] shell input swipe [x1] [y1] [x2] [y2] [duration]",
                 "display": "[Adb] -s [Address] shell dumpsys window displays | grep init= | awk ' { print $3 } '",
                 "displayFormat": "cur=%dx%d",
+                "displayId": "",
                 "screencapRawWithGzip": "[Adb] -s [Address] exec-out \"screencap | gzip -1\"",
                 "screencapEncode": "[Adb] -s [Address] exec-out screencap -p",
                 "release": "[Adb] kill-server"
@@ -153,6 +158,7 @@
                 "swipe": "[Adb] -s [Address] shell input swipe [x1] [y1] [x2] [y2] [duration]",
                 "display": "[Adb] -s [Address] shell dumpsys window displays | grep init= | awk ' { print $3 } '",
                 "displayFormat": "cur=%dx%d",
+                "displayId": "",
                 "screencapRawWithGzip": "[Adb] -s [Address] exec-out \"screencap | gzip -1\"",
                 "screencapEncode": "[Adb] -s [Address] exec-out screencap -p",
                 "release": "[Adb] kill-server"
@@ -175,8 +181,32 @@
                 "swipe": "[Adb] -s [Address] shell input swipe [x1] [y1] [x2] [y2] [duration]",
                 "display": "[Adb] -s [Address] shell dumpsys window displays | grep init=",
                 "displayFormat": "    init=%dx%d",
+                "displayId": "",
                 "screencapRawWithGzip": "[Adb] -s [Address] shell \"screencap | gzip -1\"",
                 "screencapEncode": "[Adb] -s [Address] shell screencap -p",
+                "release": "[Adb] kill-server"
+            }
+        },
+        "WSA": {
+            "handle": {
+                "class": "com.hypergryph.arknights",
+                "window": "明日方舟"
+            },
+            "adb": {
+                "path": "[ExecDir]platform-tools\\adb.exe",
+                "addresses": [
+                    "127.0.0.1:58526"
+                ],
+                "devices": "[Adb] devices",
+                "addressRegex": "(.+)\tdevice",
+                "connect": "[Adb] connect [Address]",
+                "click": "[Adb] -s [Address] shell input -d [DisplayId] tap [x] [y]",
+                "swipe": "[Adb] -s [Address] shell input -d [DisplayId] swipe [x1] [y1] [x2] [y2] [duration]",
+                "display": "[Adb] -s [Address] shell \"wm size -d [DisplayId]\"",
+                "displayFormat": "Physical size:%dx%d",
+                "displayId": "[Adb] -s [Address] shell dumpsys display | grep mUniqueId=virtual:com.microsoft.windows.systemapp:com.hypergryph.arknights",
+                "screencapRawWithGzip": "[Adb] -s [Address] shell \"screencap -d [DisplayId] | gzip -1\"",
+                "screencapEncode": "[Adb] -s [Address] shell screencap -d [DisplayId] -p",
                 "release": "[Adb] kill-server"
             }
         },
@@ -196,6 +226,7 @@
                 "click": "[Adb] -s [Address] shell input tap [x] [y]",
                 "swipe": "[Adb] -s [Address] shell input swipe [x1] [y1] [x2] [y2] [duration]",
                 "display": "[Adb] -s [Address] shell dumpsys window displays | grep init=",
+                "displayId": "",
                 "displayFormat": "    init=%dx%d",
                 "screencapRawWithGzip": "[Adb] -s [Address] exec-out \"screencap | gzip -1\"",
                 "screencapEncode": "[Adb] -s [Address] exec-out screencap -p",

--- a/src/MeoAssistant/AsstDef.h
+++ b/src/MeoAssistant/AsstDef.h
@@ -274,6 +274,7 @@ namespace asst
         std::string swipe;
         std::string display;
         std::string display_format;
+        std::string display_id;
         std::string screencap_raw_with_gzip;
         std::string screencap_encode;
         std::string release;

--- a/src/MeoAssistant/AsstUtils.hpp
+++ b/src/MeoAssistant/AsstUtils.hpp
@@ -31,6 +31,15 @@ namespace asst
             return str;
         }
 
+        inline std::string string_replace_all_batch(const std::string& src, const std::vector<std::pair<std::string, std::string>>& replace_pairs)
+        {
+            std::string str = src;
+            for (auto &[old_value, new_value] : replace_pairs) {
+                str = string_replace_all(str, old_value, new_value);
+            }
+            return str;
+        }
+
         inline std::vector<std::string> string_split(const std::string& str, const std::string& delimiter)
         {
             std::string::size_type pos1 = 0;

--- a/src/MeoAssistant/Controller.cpp
+++ b/src/MeoAssistant/Controller.cpp
@@ -110,6 +110,8 @@ bool asst::Controller::connect_adb(const std::string & address)
     std::string connect_cmd = utils::string_replace_all(
         utils::string_replace_all(m_emulator_info.adb.connect, "[Adb]", m_emulator_info.adb.path),
         "[Address]", address);
+
+    std::string display_id;
     auto connect_ret = call_command(connect_cmd);
     // 端口即使错误，命令仍然会返回0，TODO 对connect_result进行判断
     if (!connect_ret) {
@@ -136,17 +138,18 @@ bool asst::Controller::connect_adb(const std::string & address)
             return false;
         }
 
-        m_emulator_info.adb.display_id = display_id_pipe_str.substr(last + 1);
+        display_id = display_id_pipe_str.substr(last + 1);
         // 去掉换行
-        m_emulator_info.adb.display_id.pop_back();
+        display_id.pop_back();
     }
+    std::vector<std::pair<std::string, std::string>> replaces = {
+        {"[Adb]", m_emulator_info.adb.path},
+        {"[Address]", address},
+        {"[DisplayId]", display_id}
+    };
 
-
-    std::string display_cmd = utils::string_replace_all(
-        utils::string_replace_all(
-        utils::string_replace_all(m_emulator_info.adb.display, "[Adb]", m_emulator_info.adb.path),
-        "[Address]", address),
-        "[DisplayId]", m_emulator_info.adb.display_id);
+    std::string display_cmd = utils::string_replace_all_batch(
+        m_emulator_info.adb.display, replaces);
 
     auto display_ret = call_command(display_cmd);
     if (!display_ret) {
@@ -183,11 +186,7 @@ bool asst::Controller::connect_adb(const std::string & address)
         m_scale_size = std::make_pair(WindowWidthDefault, scale_height);
         m_control_scale = static_cast<double>(m_emulator_info.adb.display_width) / static_cast<double>(WindowWidthDefault);
     }
-    std::vector<std::pair<std::string, std::string>> replaces = {
-        {"[Adb]", m_emulator_info.adb.path},
-        {"[Address]", address},
-        {"[DisplayId]", m_emulator_info.adb.display_id}
-    };
+    
     m_emulator_info.adb.click = utils::string_replace_all_batch(
         m_emulator_info.adb.click, replaces);
     m_emulator_info.adb.swipe = utils::string_replace_all_batch(

--- a/src/MeoAssistant/GeneralConfiger.cpp
+++ b/src/MeoAssistant/GeneralConfiger.cpp
@@ -50,6 +50,7 @@ bool asst::GeneralConfiger::parse(const json::value& json)
         emulator_info.adb.click = adb_json.at("click").as_string();
         emulator_info.adb.swipe = adb_json.at("swipe").as_string();
         emulator_info.adb.display = adb_json.at("display").as_string();
+        emulator_info.adb.display_id = adb_json.at("displayId").as_string();
         emulator_info.adb.display_format = adb_json.at("displayFormat").as_string();
         emulator_info.adb.screencap_raw_with_gzip = adb_json.at("screencapRawWithGzip").as_string();
         emulator_info.adb.screencap_encode = adb_json.at("screencapEncode").as_string();


### PR DESCRIPTION
微软已经实现了WSA截屏所需要的接口，但是WSA似乎每个app是运行在独立的屏幕上的，故`screencap`和`input` 要添加`-d` 参数指定屏幕。
在`screencap`和`input`命令中增加了`[DisplayId]`用于表示屏幕ID的支持。
在`adb_connect`中添加了明日方舟的`display_id`的获取。
增加了一个实验性的国服的WSA支持，窗口`class`是包名，`title`是`app`的名称。
`display_id`获取以及根据窗口句柄找WSA需要针对不同服进一步适配（暂时没下外服包确认）。